### PR TITLE
Stopped `getFreeTcpPort()` from suppressing errors

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -22,9 +22,6 @@ function installSpotifyAppIfNeeded($w)
 
 function getFreeTcpPort()
 {
-	//avoid warnings like this PHP Warning:  fsockopen(): unable to connect to localhost (Connection refused) 
-	error_reporting(~E_ALL);
-	
 	$from = 10000;
 	$to = 20000;
 	 
@@ -33,7 +30,8 @@ function getFreeTcpPort()
 	 
 	for($port = $from; $port <= $to ; $port++)
 	{
-	  $fp = fsockopen($host , $port);
+	  //avoid warnings like this PHP Warning:  fsockopen(): unable to connect to localhost (Connection refused) 
+	  $fp = @fsockopen($host , $port);
 		if (!$fp)
 		{
 			//port is free


### PR DESCRIPTION
I'm using your `getFreeTcpPort()` method in my scripts, but I modified it to keep it from permanently suppressing errors in the script.

I was getting silent fails in my sockets until this change.

btw thanks for the documentation reference! Much appreciated!
